### PR TITLE
Add Resolve-ArmUtcNowFunction and tests

### DIFF
--- a/src/private/Resolve-ArmutcNowFunction.ps1
+++ b/src/private/Resolve-ArmutcNowFunction.ps1
@@ -1,10 +1,22 @@
 Function Resolve-ArmutcNowFunction {
     [cmdletbinding()]
     param (
-        [parameter(Mandatory)]
-        [ArmValue[]]$Arguments,
+        [parameter()]
+        [ArmStringValue]$Arguments,
 
         [parameter()]
         [TemplateRootAst]$Template
     )
+
+    if ($Template -isnot [TemplateParameterAst]) {
+        Write-Error -Message "You can't use UtcNow function except in the Parameters block of a tempalte"
+    }
+    else {
+        if ($Arguments) {
+            (Get-Date).ToString($Arguments.ToString())
+        }
+        else {
+            (Get-Date).ToString('yyyyMMddTHHmmssZ')
+        }
+    }
 }

--- a/tests/unit/Resolve-ArmUtcNowFunction.Tests.ps1
+++ b/tests/unit/Resolve-ArmUtcNowFunction.Tests.ps1
@@ -1,0 +1,42 @@
+using module ..\..\Output\ArmTemplateValidation
+
+InModuleScope ArmTemplateValidation {
+
+    Describe "Testing Resolve-ArmUtcNowFunction" -Tag "Resolve-ArmUtcNowFunction" {
+
+        BeforeAll {
+            Mock -CommandName Get-Date -MockWith {
+                [DateTime]::new(1970,01,01,12,00,00)
+            }
+            $Parameter = [PSCustomObject]@{
+                type = 'string'
+            }
+            $ParameterAst = [TemplateParameterAst]::New('Test',$Parameter, [TemplateRootAst]::New())
+        }
+
+        It "Should throw when tempalte isn't a TemplateParameterAst" {
+            $BadAst = [TemplateRootAst]::New()
+
+            {Resolve-ArmUtcNowFunction -Arguments 'yyyy' -Template $BadAst} | Should -Throw
+        }
+
+        It "Should resolve to ISO 8601 (yyyyMMddTHHmmssZ) when no arguments are provided" {
+            $Sut = Resolve-ArmUtcNowFunction -Template $ParameterAst
+
+            $Sut | Should -Be '19700101T120000Z'
+        }
+
+        It "Should resolve to dd-MM-yyyy when provided that format as an argument" {
+            $argumentValue = [ArmStringValue]::New(
+                [ArmToken]::Create(
+                    [ArmTokenType]::QuotedString,
+                    0,
+                    'dd-MM-yyyy'
+                )
+            )
+            $Sut = Resolve-ArmUtcNowFunction -Arguments $argumentValue -Template $ParameterAst
+
+            $Sut | Should -Be '01-01-1970'
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add function to resolve UtcNow ARM function. Should throw an error if the Ast element it's being called in isn't a TemplateParameterAst.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
