### PR TITLE
Add constructor for TemplateOutputAst objects

### DIFF
--- a/src/classes/060-TemplateOutputAst.ps1
+++ b/src/classes/060-TemplateOutputAst.ps1
@@ -3,4 +3,18 @@ class TemplateOutputAst : TemplateRootAst {
     [string]$Type
 
     [PSObject]$Value
+
+    TemplateOutputAst ([string]$OutputName, [PSCustomObject]$InputObject, [TemplateRootAst]$Parent) {
+        $this.Parent = $Parent
+
+        if (-not($InputObject.type)) {
+            Write-Error -Message "Output - Missing required properties, expected: Type" -ErrorAction Stop
+        }
+
+        $this.Name = $OutputName
+
+        foreach ($Property in $InputObject.PSObject.Properties.Name) {
+            $this.$Property = $InputObject.$Property
+        }
+    }
 }

--- a/tests/unit/060-TemplateOutputAst.Tests.ps1
+++ b/tests/unit/060-TemplateOutputAst.Tests.ps1
@@ -1,0 +1,22 @@
+using module ..\..\Output\ArmTemplateValidation
+
+InModuleScope ArmTemplateValidation {
+
+    Describe "Testing TemplateOutputAst" -Tag "TemplateOutputAst" {
+
+        Context "Testing constructor" {
+
+            BeforeAll {
+                $EmptyParent = [TemplateRootAst]::New()
+                $MissingType = [PSCustomObject]@{
+                    Value = '1234'
+                }
+            }
+
+            It "Throws an error when required properties aren't provided" {
+                {[TemplateOutputAst]::New('MissingType', $MissingType, $EmptyParent)} | Should -Throw "Output - Missing required properties, expected: Type"
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add a simple constructor for the TemplateOutputAst class and some tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

