### PR TITLE
Update TemplateAst and tests to handle templates with empty blocks

### DIFF
--- a/src/classes/020-TemplateAst.ps1
+++ b/src/classes/020-TemplateAst.ps1
@@ -81,19 +81,19 @@ class TemplateAst : TemplateRootAst {
             $this.ApiProfile = $InputObject.ApiProfile
         }
 
-        if ($InputObject.Parameters) {
+        if ($InputObject.Parameters -and (Get-Member -InputObject $InputObject.Parameters | Measure-Object).Count -gt 4) {
             $this.SetParameters($InputObject)
         }
 
-        if ($InputObject.Variables) {
+        if ($InputObject.Variables -and (Get-Member -InputObject $InputObject.Variables | Measure-Object).Count -gt 4) {
             $this.SetVariables($InputObject)
         }
 
-        if ($InputObject.Functions) {
+        if ($InputObject.Functions -and (Get-Member -InputObject $InputObject.Functions | Measure-Object).Count -gt 4) {
             $this.SetFunctions($InputObject)
         }
 
-        if ($InputObject.Outputs) {
+        if ($InputObject.Outputs -and (Get-Member -InputObject $InputObject.Outputs | Measure-Object).Count -gt 4) {
             $this.SetOutputs($InputObject)
         }
 
@@ -125,7 +125,7 @@ class TemplateAst : TemplateRootAst {
 
     [void] SetOutputs ([PSCustomObject]$InputObject) {
         $this.Outputs = foreach ($Output in $InputObject.Outputs.PSObject.Properties.Name) {
-            [TemplateOutputAst]::New($Output, $InputObject.Outputs.$Output, $this)
+            [TemplateOutputAst]::New($Output, $InputObject.outputs.$Output, $this)
         }
     }
 

--- a/tests/unit/020-TemplateAst.Tests.ps1
+++ b/tests/unit/020-TemplateAst.Tests.ps1
@@ -95,7 +95,7 @@ InModuleScope ArmTemplateValidation {
                 }
 
                 It "Should have function of type TemplateFunctionAst" {
-                    $Sut.Functions.GetType().Name | Should -Be 'TemplateFunctionAst'
+                    $Sut.Functions.GetType().Name | Should -Be 'TemplateFunctionAst[]'
                 }
             }
         }
@@ -116,7 +116,11 @@ InModuleScope ArmTemplateValidation {
                 $ValidTemplate = [PSCustomObject]@{
                     '$schema' = 'ValidSchema'
                     contentVersion = '2.0.0.0'
-                    resources = 'ValidResources'
+                    resources = [PSCustomObject]@{
+                        Name = 'ExampleResource'
+                        Type = 'Microsoft.Test/Resource'
+                        ApiVersion = '1970-01-01'
+                    }
                 }
             }
 
@@ -130,6 +134,10 @@ InModuleScope ArmTemplateValidation {
 
             It "Should write an error when a template with no resources is provided" {
                 {[TemplateAst]::New($NoResources)} | Should -Throw "Invalid template provided"
+            }
+
+            It "Should not write an error when a valid template is provided" {
+                {[TemplateAst]::New($ValidTemplate)} | Should -Not -Throw
             }
 
         }
@@ -152,7 +160,11 @@ InModuleScope ArmTemplateValidation {
                 $ValidTemplate = [PSCustomObject]@{
                     '$schema' = 'ValidSchema'
                     contentVersion = '2.0.0.0'
-                    resources = 'ValidResources'
+                    resources = [PSCustomObject]@{
+                        Name = 'ExampleResource'
+                        Type = 'Microsoft.Test/Resource'
+                        ApiVersion = '1970-01-01'
+                    }
                 }
             }
 
@@ -166,6 +178,10 @@ InModuleScope ArmTemplateValidation {
 
             It "Should write an error when a template with no resources is provided" {
                 {[TemplateAst]::New($NoResources, $EmptyParent)} | Should -Throw "Invalid template provided"
+            }
+
+            It "Should not write an error when a valid template is provided" {
+                {[TemplateAst]::New($ValidTemplate, $EmptyParent)} | Should -Not -Throw
             }
 
         }


### PR DESCRIPTION
## Description

Templates may have empty Parameters, Variables, Functions or Outputs sections, this adds support for those and ensures they are being checked correctly both for existence and that they have more than the 4 default members that a custom object has.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

