### PR TITLE
Add support for resolving the value of a parameter being passed to a nested template

### DIFF
--- a/tests/unit/050-TemplateResourceAst.Tests.ps1
+++ b/tests/unit/050-TemplateResourceAst.Tests.ps1
@@ -5,6 +5,7 @@ InModuleScope ArmTemplateValidation {
     Describe "Testing TemplateResourceAst" -Tag "TemplateResourceAst" {
 
         BeforeAll {
+            Mock -CommandName Resolve-ArmFunction -MockWith {'Test'}
             $EmptyParent = [TemplateRootAst]::New()
         }
 
@@ -154,6 +155,14 @@ InModuleScope ArmTemplateValidation {
 
                 It "Should transform the nested template into a TemplateAst" {
                     $Sut.Properties.Template.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should add the raw value of the StoragAccountName parameter to the parameter object for passing into the nested template" {
+                    $Sut.Properties.Parameters.StorageAccountName.ValueRaw | Should -Be 'testName'
+                }
+
+                It "Should add the raw value of the location parameter to the parameter object for passing into the nested template" {
+                    $Sut.Properties.Parameters.location.ValueRaw | Should -Be 'WestEurope'
                 }
 
             }


### PR DESCRIPTION
## Description

Add support for resolving the value of a parameter being passed to a nested template. Currently they are left at whatever is in the template, which could be a language expression or a string or an object or anything. This will fix whatever is in there to it's correct ARM type so that Get-ArmPropertyValue can find it from a nested template.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

