### PR TITLE
Add Invoke-ArmTemplateValidation function - fixes #15

### DIFF
--- a/docs/en-GB/Invoke-ArmTemplateValidation.md
+++ b/docs/en-GB/Invoke-ArmTemplateValidation.md
@@ -1,0 +1,160 @@
+---
+external help file: ArmTemplateValidation-help.xml
+Module Name: ArmTemplateValidation
+online version:
+schema: 2.0.0
+---
+
+# Invoke-ArmTemplateValidation
+
+## SYNOPSIS
+
+Validates that a provided ARM template is actually valid ARM without calling the ARM API.
+
+## SYNTAX
+
+```
+Invoke-ArmTemplateValidation [-Path] <String> [[-Parameters] <Hashtable>] [[-ParameterFile] <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Validates that a provided ARM template is actually valid ARM without calling the ARM API.
+
+Any parameters or variables within the templates are expanded out where possible and any ARM functions
+are ran, with some dummy values being populated in various situations where the API would generate it.
+
+The function will return a TemplateAst object, containing the template and all it's nested resources, parameters, variables, outputs, and functions. The object will contain a Valid property which indicates if the template itself is actually valid. In the case where it is not a valid template then the Errors property will contain a list of issues that have been found with the template.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Invoke-ArmTemplateValidation -Path C:\Templates\azuredeploy.json
+
+$Schema        : https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#
+ContentVersion : 1.0.0.0
+Valid          : True
+ApiProfile     :
+Parameters     :
+Variables      :
+Resources      : {teststorageaccount}
+Outputs        :
+Functions      :
+Errors         :
+Name           :
+Parent         :
+```
+
+This will return a TemplateAst object that shows the various properties of an ARM template and if it's a valid template.
+
+### Example 2
+
+```powershell
+PS C:\> Invoke-ArmTemplateValidation -Path C:\Templates\azuredeploy.json -ParameterFile C:\Templates\azuredeploy.parameters.json
+
+$Schema        : https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#
+ContentVersion : 1.0.0.0
+Valid          : True
+ApiProfile     :
+Parameters     : {StorageAccountName}
+Variables      :
+Resources      : {[parameters('StorageAccountName')]}
+Outputs        :
+Functions      :
+Errors         :
+Name           :
+Parent         :
+```
+
+This will take a template and it's related parameters file and then return a TemplateAst object that shows the various properties of an ARM template and if it's a valid template. Any values in the parameters file will be populated into the Value property on the relevant parameter in the template. If a parameter is provided in the Parameters file but not on the template then an error will be written out, rather than adding to the Errors log as the issue isn't strictly with the ARM template itself.
+
+### Example 3
+
+```powershell
+PS C:\> $Parameters = @{
+    StorageAccountName = 'teststorage'
+}
+PS C:\> Invoke-ArmTemplateValidation -Path C:\Templates\azuredeploy.json -Parameters $Parameters
+
+$Schema        : https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#
+ContentVersion : 1.0.0.0
+Valid          : True
+ApiProfile     :
+Parameters     : {StorageAccountName}
+Variables      :
+Resources      : {[parameters('StorageAccountName')]}
+Outputs        :
+Functions      :
+Errors         :
+Name           :
+Parent         :
+```
+
+This will take a template and a hashtable of parameter values and then return a TemplateAst object that shows the various properties of an ARM template and if it's a valid template. Any values in the parameters will be populated into the Value property on the relevant parameter in the template. If a parameter is provided in the Parameters but not on the template then an error will be written out, rather than adding to the Errors log as the issue isn't strictly with the ARM template itself.
+
+## PARAMETERS
+
+### -ParameterFile
+
+File path to a ARM template parameters file. Should be a local file currently.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+
+Hashtable containing ARM template parameters and the values to assign to them.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+
+File path to the ARM template to validate. Should be a local file currently.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### TemplateAst
+## NOTES
+
+## RELATED LINKS

--- a/src/classes/050-TemplateResourceAst.ps1
+++ b/src/classes/050-TemplateResourceAst.ps1
@@ -32,9 +32,7 @@ class TemplateResourceAst : TemplateRootAst {
 
         $this.Parent = $Parent
 
-        if (-not($this.HasRequiredProperties($InputObject))) {
-            Write-Error -Message "Missing one or more required properties." -ErrorAction Stop
-        }
+        $this.HasRequiredProperties($InputObject)
 
         foreach ($Property in $InputObject.PSObject.Properties.Name.Where({$_ -notin @('resources','copy','sku','plan')})) {
             $this.$Property = $InputObject.$Property
@@ -113,13 +111,16 @@ class TemplateResourceAst : TemplateRootAst {
     [bool] HasRequiredProperties ([PSCustomObject]$InputObject) {
         if (-not($InputObject.apiVersion -and
                     $InputObject.apiVersion -match '^\d{4}-\d{2}-\d{2}(-preview)?$')) {
+            $this.Parent.Errors += 'Invalid template: Resource does not contain a valid ApiVersion'
             return $false
         }
         if (-not($InputObject.type -and
                     $InputObject.type -match '[a-z\.]+(\/[a-z]+)+')) {
+            $this.Parent.Errors += 'Invalid template: Resource does not contain a valid type'
             return $false
         }
         if (-not($InputObject.name)) {
+            $this.Parent.Errors += 'Invalid template: Resource does not contain a Name'
             return $false
         }
         return $true

--- a/src/public/Invoke-ArmTemplateValidation.ps1
+++ b/src/public/Invoke-ArmTemplateValidation.ps1
@@ -1,0 +1,57 @@
+function Invoke-ArmTemplateValidation {
+    [cmdletbinding()]
+    [OutputType([TemplateAst])]
+    param (
+        [parameter(Mandatory)]
+        [ValidateScript({
+            if (-not (Test-Path -Path $_)) {
+                Write-Error "Invalid path specified from template. Please check file exists." -ErrorAction Stop
+            }
+            $true
+        })]
+        [String]$Path,
+
+        [parameter()]
+        [Hashtable]$Parameters,
+
+        [parameter()]
+        [ValidateScript({
+            if (-not (Test-Path -Path $_)) {
+                Write-Error "Invalid path specified from template parameters. Please check file exists." -ErrorAction Stop
+            }
+            $true
+        })]
+        [string]$ParameterFile
+    )
+
+    $AllParameters = @()
+
+    if ($PSBoundParameters.ContainsKey('Parameters')) {
+        foreach ($Parameter in $Parameters.Keys) {
+            $AllParameters += [PSCustomObject]@{
+                $Parameter = [PSCustomObject]@{
+                    Value = $Parameters[$Parameter]
+                }
+            }
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('ParameterFile')) {
+        $ParameterFileImport = Get-Content -Path $ParameterFile -Raw | ConvertFrom-Json
+
+        foreach ($Parameter in $ParameterFileImport.Parameters.PSObject.Properties.Name) {
+            $AllParameters += [PSCustomObject]@{
+                $Parameter = $ParameterFileImport.Parameters.$Parameter
+            }
+        }
+    }
+
+    if ($AllParameters.Count -gt 0) {
+        $Template = [TemplateAst]::New($Path, $AllParameters)
+    }
+    else {
+        $Template = [TemplateAst]::New($Path)
+    }
+
+    $Template
+}

--- a/tests/unit/020-TemplateAst.Tests.ps1
+++ b/tests/unit/020-TemplateAst.Tests.ps1
@@ -10,16 +10,16 @@ InModuleScope ArmTemplateValidation {
                 {[TemplateAst]::New("$PSScriptRoot\InvalidPath\FakeTemplate.json")} | Should -Throw "Invalid Path provided."
             }
 
-            It "Should write an error when a template with no `$schema is provided" {
-                {[TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\NoSchema.json")} | Should -Throw "Invalid template provided"
+            It "Should log an error when a template with no `$schema is provided" {
+                ([TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\NoSchema.json")).Errors | Should -Be 'Invalid Template: does not contain a $schema element'
             }
 
-            It "Should write an error when a template with no contentVersion is provided" {
-                {[TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\NoContentVersion.json")} | Should -Throw "Invalid template provided"
+            It "Should log an error when a template with no contentVersion is provided" {
+                ([TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\NoContentVersion.json")).Errors | Should -Be "Invalid Template: does not contain a contentVersion element"
             }
 
-            It "Should write an error when a template with no resources is provided" {
-                {[TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\NoResources.json")} | Should -Throw "Invalid template provided"
+            It "Should log an error when a template with no resources is provided" {
+                ([TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\NoResources.json")).Errors | Should -Be "Invalid Template: does not contain any resources"
             }
 
             Context "Template with a single resource" {
@@ -124,20 +124,20 @@ InModuleScope ArmTemplateValidation {
                 }
             }
 
-            It "Should write an error when a template with no `$schema is provided" {
-                {[TemplateAst]::New($NoSchema)} | Should -Throw "Invalid template provided"
+            It 'Should write an error when a template with no $schema is provided' {
+                ([TemplateAst]::New($NoSchema)).Errors | Should -Be 'Invalid Template: does not contain a $schema element'
             }
 
             It "Should write an error when a template with no contentVersion is provided" {
-                {[TemplateAst]::New($NoContentVersion)} | Should -Throw "Invalid template provided"
+                ([TemplateAst]::New($NoContentVersion)).Errors | Should -Be "Invalid Template: does not contain a contentVersion element"
             }
 
             It "Should write an error when a template with no resources is provided" {
-                {[TemplateAst]::New($NoResources)} | Should -Throw "Invalid template provided"
+                ([TemplateAst]::New($NoResources)).Errors | Should -Be "Invalid Template: does not contain any resources"
             }
 
             It "Should not write an error when a valid template is provided" {
-                {[TemplateAst]::New($ValidTemplate)} | Should -Not -Throw
+                ([TemplateAst]::New($ValidTemplate)).Errors.Count | Should -Be 0
             }
 
         }
@@ -168,20 +168,20 @@ InModuleScope ArmTemplateValidation {
                 }
             }
 
-            It "Should write an error when a template with no `$schema is provided" {
-                {[TemplateAst]::New($NoSchema, $EmptyParent)} | Should -Throw "Invalid template provided"
+            It 'Should write an error when a template with no $schema is provided' {
+                ([TemplateAst]::New($NoSchema, $EmptyParent)).Errors | Should -Be 'Invalid Template: does not contain a $schema element'
             }
 
             It "Should write an error when a template with no contentVersion is provided" {
-                {[TemplateAst]::New($NoContentVersion, $EmptyParent)} | Should -Throw "Invalid template provided"
+                ([TemplateAst]::New($NoContentVersion, $EmptyParent)).Errors | Should -Be "Invalid Template: does not contain a contentVersion element"
             }
 
             It "Should write an error when a template with no resources is provided" {
-                {[TemplateAst]::New($NoResources, $EmptyParent)} | Should -Throw "Invalid template provided"
+                ([TemplateAst]::New($NoResources, $EmptyParent)).Errors | Should -Be "Invalid Template: does not contain any resources"
             }
 
             It "Should not write an error when a valid template is provided" {
-                {[TemplateAst]::New($ValidTemplate, $EmptyParent)} | Should -Not -Throw
+                ([TemplateAst]::New($ValidTemplate, $EmptyParent)).Errors.Count | Should -Be 0
             }
 
         }

--- a/tests/unit/050-TemplateResourceAst.Tests.ps1
+++ b/tests/unit/050-TemplateResourceAst.Tests.ps1
@@ -6,7 +6,10 @@ InModuleScope ArmTemplateValidation {
 
         BeforeAll {
             Mock -CommandName Resolve-ArmFunction -MockWith {'Test'}
-            $EmptyParent = [TemplateRootAst]::New()
+        }
+
+        BeforeEach {
+            $EmptyParent = [TemplateAst]::New()
         }
 
         Context "Testing constructor with object" {
@@ -34,39 +37,44 @@ InModuleScope ArmTemplateValidation {
                     apiVersion = '2018-07-10'
                     Type = 'Microsoft.Sql/SqlServer'
                 }
-
             }
 
             $RequiredProperties = @(
                 @{
                     RequiredProperty = 'apiVersion'
                     InputObject = $NoApiVersion
+                    Message = 'a valid ApiVersion'
                 }
                 @{
                     RequiredProperty = 'valid apiVersion'
                     InputObject = $InvalidApiVersion
+                    Message = 'a valid ApiVersion'
                 }
                 @{
                     RequiredProperty = 'type'
                     InputObject = $NoType
+                    Message = 'a valid type'
                 }
                 @{
                     RequiredProperty = 'valid type'
                     InputObject = $InvalidType
+                    Message = 'a valid type'
                 }
                 @{
                     RequiredProperty = 'name'
                     InputObject = $NoName
+                    Message = 'a Name'
                 }
             )
 
-            It "Should write an error when no <RequiredProperty> is provided" {
+            It "Should log an error when <RequiredProperty> is not provided" {
                 Param (
                     $RequiredProperty,
-                    $InputObject
+                    $InputObject,
+                    $Message
                 )
 
-                {[TemplateResourceAst]::New($InputObject, $EmptyParent)} | Should -Throw "Missing one or more required properties."
+                ([TemplateResourceAst]::New($InputObject, $EmptyParent)).Parent.Errors | Should -Be "Invalid template: Resource does not contain $message"
 
             } -TestCases $RequiredProperties
 

--- a/tests/unit/Invoke-ArmTemplateValidation.Tests.ps1
+++ b/tests/unit/Invoke-ArmTemplateValidation.Tests.ps1
@@ -1,0 +1,214 @@
+using module ..\..\Output\ArmTemplateValidation
+
+InModuleScope ArmTemplateValidation {
+
+    Describe "Testing Invoke-ArmTemplateValidation" -Tag "Invoke-ArmTemplateValidation" {
+
+        Context "When providing just a template" {
+
+            Context "For a valid template" {
+
+                BeforeAll {
+                    $Sut = Invoke-ArmTemplateValidation -Path "$PSScriptRoot\TestData\InvokeTemplateValidation\OneResource.json"
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have no errors" {
+                    $Sut.Errors.Count | Should -Be 0
+                }
+
+                It "Should be return true for the valid property of the template" {
+                    $Sut.Valid | Should -Be $True
+                }
+
+            }
+
+            Context "For an invalid tempalte" {
+
+                BeforeAll {
+                    $Sut = Invoke-ArmTemplateValidation -Path "$PSScriptRoot\TestData\InvokeTemplateValidation\NoResources.json"
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have 1 error" {
+                    $Sut.Errors.Count | Should -Be 1
+                    $Sut.Errors | Should -Be 'Invalid template: Does not contain any resources'
+                }
+
+                It "Should be return false for the valid property of the template" {
+                    $Sut.Valid | Should -Be $false
+                }
+            }
+        }
+
+        Context "When providing a template and parameter file" {
+
+            Context "For a valid template" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\Parameters.json"
+                        ParameterFile = "$PSScriptRoot\TestData\InvokeTemplateValidation\parameters.parameters.json"
+                    }
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have no errors" {
+                    $Sut.Errors.Count | Should -Be 0
+                }
+
+                It "Should be return true for the valid property of the template" {
+                    $Sut.Valid | Should -Be $True
+                }
+            }
+
+            Context "For an invalid tempalte" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\InvalidParameters.json"
+                        ParameterFile = "$PSScriptRoot\TestData\InvokeTemplateValidation\parameters.parameters.json"
+                    }
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have 1 error" {
+                    $Sut.Errors.Count | Should -Be 1
+                    $Sut.Errors | Should -Be 'Invalid template: Resource does not contain a valid type'
+                }
+
+                It "Should be return false for the valid property of the template" {
+                    $Sut.Valid | Should -Be $false
+                }
+            }
+        }
+
+        Context "When providing a template and parameters hashtable" {
+
+            Context "For a valid template" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\Parameters.json"
+                        Parameters = @{
+                            StorageAccountName = 'testname'
+                        }
+                    }
+
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have no errors" {
+                    $Sut.Errors.Count | Should -Be 0
+                }
+
+                It "Should be return true for the valid property of the template" {
+                    $Sut.Valid | Should -Be $True
+                }
+
+            }
+
+            Context "For an invalid tempalte" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\InvalidParameters.json"
+                        Parameters = @{
+                            StorageAccountName = 'testname'
+                        }
+                    }
+
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have 1 error" {
+                    $Sut.Errors.Count | Should -Be 1
+                    $Sut.Errors | Should -Be 'Invalid template: Resource does not contain a valid type'
+                }
+
+                It "Should be return false for the valid property of the template" {
+                    $Sut.Valid | Should -Be $false
+                }
+            }
+        }
+
+        Context "When providing a template, parameter file, and parameters hashtable" {
+
+            Context "For a valid template" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\MultipleParameters.json"
+                        ParameterFile = "$PSScriptRoot\TestData\InvokeTemplateValidation\parameters.parameters.json"
+                        Parameters = @{
+                            StorageSku = 'Standard_LRS'
+                        }
+                    }
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have no errors" {
+                    $Sut.Errors.Count | Should -Be 0
+                }
+
+                It "Should be return true for the valid property of the template" {
+                    $Sut.Valid | Should -Be $True
+                }
+
+            }
+
+            Context "For an invalid tempalte" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\InvalidMultipleParameters.json"
+                        ParameterFile = "$PSScriptRoot\TestData\InvokeTemplateValidation\parameters.parameters.json"
+                        Parameters = @{
+                            StorageSku = 'Standard_LRS'
+                        }
+                    }
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have 1 error" {
+                    $Sut.Errors.Count | Should -Be 1
+                    $Sut.Errors | Should -Be 'Invalid template: Resource does not contain a valid type'
+                }
+
+                It "Should be return false for the valid property of the template" {
+                    $Sut.Valid | Should -Be $false
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/InvalidMultipleParameters.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/InvalidMultipleParameters.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "StorageAccountName": {
+            "type": "string"
+        },
+        "StorageSku": {
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "name": "[parameters('StorageAccountName')]",
+            "location": "WestEurope",
+            "apiVersion": "2018-07-01",
+            "sku": {
+              "name": "[parameters('StorageSku')]"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+          }
+    ],
+    "outputs": {}
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/InvalidParameters.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/InvalidParameters.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "StorageAccountName": {
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "name": "[parameters('StorageAccountName')]",
+            "location": "WestEurope",
+            "apiVersion": "2018-07-01",
+            "sku": {
+              "name": "Standard_LRS"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+          }
+    ],
+    "outputs": {}
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/MultipleParameters.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/MultipleParameters.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "StorageAccountName": {
+            "type": "string"
+        },
+        "StorageSku": {
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('StorageAccountName')]",
+            "location": "WestEurope",
+            "apiVersion": "2018-07-01",
+            "sku": {
+                "name": "[parameters('StorageSku')]"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+          }
+    ],
+    "outputs": {}
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/NoResources.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/NoResources.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "variables": {},
+    "resources": [],
+    "outputs": {}
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/OneResource.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/OneResource.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "teststorageaccount",
+            "location": "WestEurope",
+            "apiVersion": "2018-07-01",
+            "sku": {
+              "name": "Standard_LRS"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+          }
+    ],
+    "outputs": {}
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/Parameters.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/Parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "StorageAccountName": {
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('StorageAccountName')]",
+            "location": "WestEurope",
+            "apiVersion": "2018-07-01",
+            "sku": {
+              "name": "Standard_LRS"
+            },
+            "kind": "StorageV2",
+            "properties": {}
+          }
+    ],
+    "outputs": {}
+}

--- a/tests/unit/TestData/InvokeTemplateValidation/parameters.parameters.json
+++ b/tests/unit/TestData/InvokeTemplateValidation/parameters.parameters.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "StorageAccountName": {
+        "value": "testname"
+      }
+    }
+}


### PR DESCRIPTION
## Description

Add the Invoke-ArmTemplateValidation function which is the main way to interact with the functionality of the module.

It should allow passing in a parameters file and/or parameters hashtable and then populating the parameters within the template with those values.

## Related Issue
#15 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.