### PR TITLE
Push errors up a level when generating a tempalte if the parent is a ResourceAst

### DIFF
--- a/src/classes/020-TemplateAst.ps1
+++ b/src/classes/020-TemplateAst.ps1
@@ -114,6 +114,11 @@ class TemplateAst : TemplateRootAst {
 
         if ($this.Errors.count -gt 0) {
             $this.Valid = $false
+
+            if ($null -ne $this.Parent -and $this.Parent -is [TemplateResourceAst]) {
+                $this.Parent.Parent.Errors += $this.Errors
+                $this.Parent.Parent.Valid = $false
+            }
         }
 
     }


### PR DESCRIPTION
## Description

When errors are reported in a TemplateAst they won't be pushed up to higher levels of the template if they exist. We need to do this to make the errors more discoverable. Adding extra detail to these errors would be useful in future as well.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

