### PR TITLE
Fix issue with multiple objects not being correctly expanded

### DIFF
--- a/src/classes/020-TemplateAst.ps1
+++ b/src/classes/020-TemplateAst.ps1
@@ -131,11 +131,11 @@ class TemplateAst : TemplateRootAst {
 
     [void] SetParameters ([PSCustomObject]$InputObject) {
         $this.Parameters = foreach ($Parameter in $InputObject.Parameters.PSObject.Properties.Name) {
-            if ($this.ParameterValues -and $Parameter -in ($this.ParameterValues | Get-Member -MemberType NoteProperty).Name) {
+            if ($this.ParameterValues -and $Parameter -in ($this.ParameterValues | Foreach-Object { ($_ | Get-Member -MemberType NoteProperty).Name})) {
                 $AddMemberSplat = @{
                     InputObject = $InputObject.Parameters.$Parameter
                     Name = 'Value'
-                    Value = $InputObject.Parameters.$Parameter.Value
+                    Value = $this.ParameterValues.$Parameter.Value
                     Type = "NoteProperty"
                 }
 
@@ -164,7 +164,7 @@ class TemplateAst : TemplateRootAst {
     }
 
     [bool] ValidateParameterValues ([PSCustomObject]$InputObject, [PSCustomObject[]]$ParameterValues) {
-        foreach ($Parameter in ($ParameterValues | Get-Member -MemberType NoteProperty).Name) {
+        foreach ($Parameter in ($ParameterValues | Foreach-Object { ($_ | Get-Member -MemberType NoteProperty).Name})) {
 
             if (-not $InputObject.Parameters.$Parameter) {
                 Write-Error -Message "No parameter for $Parameter found in this template. Can't use value provided."

--- a/tests/unit/Invoke-ArmTemplateValidation.Tests.ps1
+++ b/tests/unit/Invoke-ArmTemplateValidation.Tests.ps1
@@ -152,6 +152,42 @@ InModuleScope ArmTemplateValidation {
                     $Sut.Valid | Should -Be $false
                 }
             }
+
+            Context "For a valid template with multiple parameters" {
+
+                BeforeAll {
+                    $InvokeSplat = @{
+                        Path = "$PSScriptRoot\TestData\InvokeTemplateValidation\MultipleParameters.json"
+                        Parameters = @{
+                            StorageAccountName = 'testname'
+                            StorageSku = 'Standard_LRS'
+                        }
+                    }
+
+                    $Sut = Invoke-ArmTemplateValidation @InvokeSplat
+                }
+
+                It "Should return a TemplateAst object" {
+                    $Sut.GetType().Name | Should -Be 'TemplateAst'
+                }
+
+                It "Should have no errors" {
+                    $Sut.Errors.Count | Should -Be 0
+                }
+
+                It "Should be return true for the valid property of the template" {
+                    $Sut.Valid | Should -Be $True
+                }
+
+                It "Should set StorageAccoutName parameter value to 'testname'" {
+                    $Sut.Parameters.Where({$_.Name -eq 'StorageAccountName'}).Value | Should -Be 'testname'
+                }
+
+                It "Should set StorageSku parameter value to 'Standard_LRS'" {
+                    $Sut.Parameters.Where({$_.Name -eq 'StorageSku'}).Value | Should -Be 'Standard_LRS'
+                }
+
+            }
         }
 
         Context "When providing a template, parameter file, and parameters hashtable" {


### PR DESCRIPTION
## Description

When passing in multiple parameters the objects created aren't being correctly expanded by the Get-Member call as each object is different. Instead we need to loop over each object, call Get-Member on it and then grab the name of it's note property (the name of the parameter in this case).

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

