### PR TITLE
Add additional parameter tests to check for other properties

### DIFF
--- a/tests/unit/030-TemplateParameterAst.Tests.ps1
+++ b/tests/unit/030-TemplateParameterAst.Tests.ps1
@@ -11,10 +11,33 @@ InModuleScope ArmTemplateValidation {
                 $MissingType = [PSCustomObject]@{
                     DefaultValue = '1234'
                 }
+                $NormalParameter = [PSCustomObject]@{
+                    type = 'string'
+                }
+                $ValueParameter = [PSCustomObject]@{
+                    type = 'string'
+                    value = 'abc123'
+                }
+                $DefaultValueParameter = [PSCustomObject]@{
+                    type = 'string'
+                    defaultValue = 'def456'
+                }
             }
 
             It "Throws an error when required properties aren't provided" {
                 {[TemplateParameterAst]::New('MissingType', $MissingType, $EmptyParent)} | Should -Throw "Missing required properties, expected: Type"
+            }
+
+            It "Should not throw when a parameter with required properties is provided" {
+                {[TemplateParameterAst]::New('NormalParameter', $NormalParameter, $EmptyParent)} | Should -Not -Throw
+            }
+
+            It "Should set the value of the parameter when provided" {
+                ([TemplateParameterAst]::New('ValueParam', $ValueParameter, $EmptyParent)).Value | Should -Be 'abc123'
+            }
+
+            It "Should set the defaultValue of the parameter when provided" {
+                ([TemplateParameterAst]::New('DefaultValueParam', $DefaultValueParameter, $EmptyParent)).DefaultValue | Should -Be 'def456'
             }
 
         }


### PR DESCRIPTION
## Description

Not enough test coverage of the ParametersAst class, mostly around the happy path approach. This adds a few more simple tests to cover that.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

