### PR TITLE
Ensure docs folder used is the en folder

### DIFF
--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -8,6 +8,7 @@ properties {
     # in the PowerShellBuild shared psake task module
     $PSBPreference.Build.CompileModule = $true
     $PSBPreference.Test.OutputFile = '../Output/testResults.xml'
+    $PSBPreference.Help.DefaultLocale = 'en'
 }
 
 task VersionManifest -action {


### PR DESCRIPTION
## Description

Docs generated by the build system go into whatever folder is currently there and new docs are generated into the system culture of the build machine. For local dev this could be en-GB or en-US, for Azure Pipelines it'll almost certainly be en-US. But to support more languages when running Get-Help locally it should be an en folder so that it falls back to that from the various en-* cultures.
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
