### PR TITLE
Update Resolve-ArmFunction to support properties of returned object

### DIFF
--- a/src/private/Resolve-ArmFunction.ps1
+++ b/src/private/Resolve-ArmFunction.ps1
@@ -19,6 +19,12 @@ Function Resolve-ArmFunction {
         $Tokens = $InputObject
     }
 
+    if ($Tokens -is [ArmPropertyAccess]) {
+        $Properties = while ($tokens -is [ArmPropertyAccess]) {
+            $Tokens.NameToken.StringValue
+            $Tokens = $Tokens.Source
+        }
+    }
     $Function = $Tokens.NameToken.StringValue
 
     $Arguments = foreach ($argument in $Tokens.ArgumentExpression) {
@@ -32,6 +38,14 @@ Function Resolve-ArmFunction {
 
     $Command = Get-Command -Name "Resolve-Arm${Function}Function"
 
-    & $Command $Arguments $Template
+    $Output = & $Command $Arguments $Template
+
+    if ($Properties) {
+        [Array]::Reverse($Properties)
+        foreach ($Prop in $Properties) {
+            $Output = $Output.$Prop
+        }
+    }
+    $Output
 }
 


### PR DESCRIPTION
## Description

Resolve-ArmFunction can't handle property accessing on the returned object currently. This fixes that by iterating down the various layers of property accessing until it finds the original function call and uses that. It keeps a list of the various properties it's found that need to be accessed and then loops over that and selects each property from the returned object.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

