### PR TITLE
Remove extra method that has been moved to the TempalteAst base type

### DIFF
--- a/src/classes/040-TemplateVariableAst.ps1
+++ b/src/classes/040-TemplateVariableAst.ps1
@@ -21,17 +21,4 @@ class TemplateVariableAst : TemplateRootAst {
         }
     }
 
-    [PSObject] ResolveValue ([PSObject]$InputObject) {
-
-        foreach ($property in $InputObject.PSObject.Properties.Name) {
-            if ($InputObject.$property.GetType().Name -eq 'PSCustomObject') {
-                $InputObject.$Property = $this.ResolveValue($InputObject.$Property)
-            }
-            elseif ($InputObject.$Property -match '^\[') {
-                $InputObject.$property = Resolve-ArmFunction -InputString $InputObject.$property -Template ($this)
-            }
-        }
-
-        return $InputObject
-    }
 }

--- a/tests/unit/030-TemplateParameterAst.Tests.ps1
+++ b/tests/unit/030-TemplateParameterAst.Tests.ps1
@@ -7,11 +7,12 @@ InModuleScope ArmTemplateValidation {
         BeforeAll {
             Mock -CommandName Resolve-ArmFunction -MockWith {'MockedValue'}
             $EmptyTemplate = [TemplateRootAst]::New()
+
         }
 
         Context "Testing constructor" {
 
-            It "Throws an error when required properties aren't provided" {
+            BeforeAll {
                 $MissingType = [PSCustomObject]@{
                     DefaultValue = '1234'
                 }
@@ -26,7 +27,9 @@ InModuleScope ArmTemplateValidation {
                     type = 'string'
                     defaultValue = 'def456'
                 }
+            }
 
+            It "Throws an error when required properties aren't provided" {
                 {[TemplateParameterAst]::New('MissingType', $MissingType, $EmptyParent)} | Should -Throw "Missing required properties, expected: Type"
             }
 


### PR DESCRIPTION
## Description

ResolveValue function has been duplicated in Variable class so needs to be removed from there so it will instead reference the one in the base class.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

