### PR TITLE
Add resources to TemplatAst after adding parameters etc

### DIFF
--- a/src/classes/020-TemplateAst.ps1
+++ b/src/classes/020-TemplateAst.ps1
@@ -90,8 +90,6 @@ class TemplateAst : TemplateRootAst {
 
         $this.ContentVersion = $InputObject.ContentVersion
 
-        $this.SetResources($InputObject)
-
         if ($InputObject.ApiProfile) {
             $this.ApiProfile = $InputObject.ApiProfile
         }
@@ -111,6 +109,8 @@ class TemplateAst : TemplateRootAst {
         if ($InputObject.Outputs -and (Get-Member -InputObject $InputObject.Outputs | Measure-Object).Count -gt 4) {
             $this.SetOutputs($InputObject)
         }
+
+        $this.SetResources($InputObject)
 
         if ($this.Errors.count -gt 0) {
             $this.Valid = $false


### PR DESCRIPTION
## Description

Currently Resources are added after the initial schema etc are set. However if we're going to attempt to resolve any references to variables, parameters, etc then we need to add the resources after all those to ensure they've been populated correctly.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

