### PR TITLE
Add support for passing parameter values into nested templates

### DIFF
--- a/src/classes/020-TemplateAst.ps1
+++ b/src/classes/020-TemplateAst.ps1
@@ -62,6 +62,13 @@ class TemplateAst : TemplateRootAst {
     TemplateAst ([PSCustomObject]$InputObject, [TemplateRootAst]$Parent) {
         $this.Parent = $Parent
 
+        if ($Parent -is [TemplateResourceAst]) {
+            $this.ParameterValues = foreach ($param in $Parent.Properties.Parameters.PSObject.Properties.Name) {
+                [PSCustomObject]@{
+                    $Param = $Parent.Properties.Parameters.$Param
+                }
+            }
+        }
         $this.HasRequiredTemplateProperties($InputObject)
         $this.SetProperties($InputObject)
     }


### PR DESCRIPTION
## Description

When using nested templates the parameters weren't being passed into the nested template using ParameterValues as they would if called with Invoke-ArmTemplateValidation.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

