### PR TITLE
Save temporary file to module root rather than temp folder

### DIFF
--- a/src/classes/050-TemplateResourceAst.ps1
+++ b/src/classes/050-TemplateResourceAst.ps1
@@ -131,7 +131,7 @@ class TemplateResourceAst : TemplateRootAst {
             $TemplateUri = Resolve-ArmFunction -InputString $TemplateUri -Template $this.Parent
         }
         if ($TemplateUri -match '^http') {
-            $TempPath = "$Env:Temp\$((New-Guid).guid).txt"
+            $TempPath = Join-Path -Path ([System.Io.Path]::GetTempPath()) -ChildPath "$((New-Guid).guid).txt"
             $TemplateOutput = Invoke-RestMethod -Uri $TemplateUri -ErrorAction Stop -OutFile $TempPath
             $TemplateOutput = Get-Content -Path $TempPath | ConvertFrom-Json
             $Null = Remove-Item -Path $TempPath


### PR DESCRIPTION
## Description

We can't guarantee permissions to save to a temporary location like $Env:Temp. Trying the .net method instead as that seems to be a bit more reliable for getting a valid path the user can work with.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

