### PR TITLE
Update Resolve-ArmResourceIdFunction to return correct-ish id

### DIFF
--- a/src/private/Resolve-ArmresourceIdFunction.ps1
+++ b/src/private/Resolve-ArmresourceIdFunction.ps1
@@ -7,4 +7,23 @@ Function Resolve-ArmresourceIdFunction {
         [parameter()]
         [TemplateRootAst]$Template
     )
+
+    $Output = "$(Resolve-ArmResourceGroupFunction -Template $Template | Select-Object -ExpandProperty Id)/"
+    $strings = $Arguments.Token.StringValue.Where({$_ -notmatch '\/subscriptions\/'})
+
+    if ($strings[0] -match '(\/\w+){2,}') {
+        $type = $strings[0] -split '\/'
+        $parent = "$($type[0])/$($type[1])"
+        $Output += "$parent/"
+
+        for ($i = 1; $i -lt $strings.count; $i++) {
+            $Output += "$($strings[$i])/"
+            $Output += "$($Type[$i+1])/"
+        }
+    }
+    else {
+        $Output += $Strings -join '/'
+    }
+
+    $Output.TrimEnd('/')
 }

--- a/tests/unit/Resolve-ArmResourceIdFunction.Tests.ps1
+++ b/tests/unit/Resolve-ArmResourceIdFunction.Tests.ps1
@@ -1,0 +1,69 @@
+using module ..\..\Output\ArmTemplateValidation
+
+InModuleScope ArmTemplateValidation {
+
+    Describe "Testing Resolve-ArmResourceIdFunction" -Tag "Resolve-ArmResourceIdFunction" {
+
+        BeforeAll {
+            $Script:SubscriptionId = '80714cf6-6d45-4a21-845c-7db81ab37921'
+            $Script:ResourceGroupName = '18d3902c-4fed-4d24-85c3-b64a09425a38'
+
+            $EmptyTemplate = [TemplateRootAst]::New()
+            $Subscription = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, "/subscriptions/$Script:SubscriptionId")))
+            $ResourceGroup = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, "/subscriptions/$Script:SubscriptionId/resourceGroups/$Script:ResourceGroupName")))
+            $ResourceType = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, 'Microsoft.Network/VirtualNetworks')))
+            $MultipleResourceType = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, 'Microsoft.Network/VirtualNetworks/Subnets')))
+            $ResourceName = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, 'VirtualNetworkName')))
+            $ResourceSubName = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, 'Subnet123')))
+        }
+
+        Context "Testing with no subscription or resource group specified and only one segment" {
+
+            It "Should return the correct full string containing the subscription, resource group, resource type, and resource name" {
+                $Sut = Resolve-ArmResourceIdFunction -Arguments $ResourceType,$ResourceName -Template $EmptyTemplate
+
+                $Sut | Should -Be '/subscriptions/80714cf6-6d45-4a21-845c-7db81ab37921/resourceGroups/18d3902c-4fed-4d24-85c3-b64a09425a38/Microsoft.Network/VirtualNetworks/VirtualNetworkName'
+            }
+        }
+
+        Context "Testing with no subscription or resource group specified and 2 segments" {
+            It "Should return the correct full string containing the subscription, resource group, resource type, and resource name" {
+                $Sut = Resolve-ArmResourceIdFunction -Arguments $MultipleResourceType,$ResourceName,$ResourceSubName -Template $EmptyTemplate
+
+                $Sut | Should -Be '/subscriptions/80714cf6-6d45-4a21-845c-7db81ab37921/resourceGroups/18d3902c-4fed-4d24-85c3-b64a09425a38/Microsoft.Network/VirtualNetworks/VirtualNetworkName/Subnets/Subnet123'
+            }
+        }
+
+        Context "Testing with no subscription but with resource group specified and only one segment" {
+            It "Should return the correct full string containing the subscription, resource group, resource type, and resource name" {
+                $Sut = Resolve-ArmResourceIdFunction -Arguments $ResourceType,$ResourceName -Template $EmptyTemplate
+
+                $Sut | Should -Be '/subscriptions/80714cf6-6d45-4a21-845c-7db81ab37921/resourceGroups/18d3902c-4fed-4d24-85c3-b64a09425a38/Microsoft.Network/VirtualNetworks/VirtualNetworkName'
+            }
+        }
+
+        Context "Testing with no subscription but with resource group specified and 2 segments" {
+            It "Should return the correct full string containing the subscription, resource group, resource type, and resource name" {
+                $Sut = Resolve-ArmResourceIdFunction -Arguments $MultipleResourceType,$ResourceName,$ResourceSubName -Template $EmptyTemplate
+
+                $Sut | Should -Be '/subscriptions/80714cf6-6d45-4a21-845c-7db81ab37921/resourceGroups/18d3902c-4fed-4d24-85c3-b64a09425a38/Microsoft.Network/VirtualNetworks/VirtualNetworkName/Subnets/Subnet123'
+            }
+        }
+
+        Context "Testing with subscription and resource group specified and only one segment" {
+            It "Should return the correct full string containing the subscription, resource group, resource type, and resource name" {
+                $Sut = Resolve-ArmResourceIdFunction -Arguments $ResourceType,$ResourceName -Template $EmptyTemplate
+
+                $Sut | Should -Be '/subscriptions/80714cf6-6d45-4a21-845c-7db81ab37921/resourceGroups/18d3902c-4fed-4d24-85c3-b64a09425a38/Microsoft.Network/VirtualNetworks/VirtualNetworkName'
+            }
+        }
+
+        Context "Testing with subscription and resource group specified and 2 segments" {
+            It "Should return the correct full string containing the subscription, resource group, resource type, and resource name" {
+                $Sut = Resolve-ArmResourceIdFunction -Arguments $MultipleResourceType,$ResourceName,$ResourceSubName -Template $EmptyTemplate
+
+                $Sut | Should -Be '/subscriptions/80714cf6-6d45-4a21-845c-7db81ab37921/resourceGroups/18d3902c-4fed-4d24-85c3-b64a09425a38/Microsoft.Network/VirtualNetworks/VirtualNetworkName/Subnets/Subnet123'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

ResourceId function returns the full ID to the resource including subscription and resource group names. We assume it's in the same subscription and resource group just to make life simpler for now. We will need to later support different resource groups and different subs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

