### PR TITLE
Add functionality to Resolve-ArmReferenceFunction

### DIFF
--- a/src/classes/020-TemplateAst.ps1
+++ b/src/classes/020-TemplateAst.ps1
@@ -131,8 +131,9 @@ class TemplateAst : TemplateRootAst {
     }
 
     [void] SetResources ([PSCustomObject]$InputObject) {
-        $this.Resources = foreach ($Resource in $InputObject.Resources) {
-            [TemplateResourceAst]::New($Resource, $this)
+        $this.Resources = @()
+        foreach ($Resource in $InputObject.Resources) {
+            $this.Resources += [TemplateResourceAst]::New($Resource, $this)
         }
     }
 

--- a/src/private/Resolve-ArmFunction.ps1
+++ b/src/private/Resolve-ArmFunction.ps1
@@ -42,14 +42,19 @@ Function Resolve-ArmFunction {
 
     if ($Properties) {
         if ($Properties[-1] -eq 'outputs') {
-            $Properties[-2] = "Where({`$_.name -eq $($Properties[-2])})"
+            $Properties[-2] = "##$($Properties[-2])##"
         }
         if ($Output -is [TemplateResourceAst]) {
             $Properties += 'Template','Properties'
         }
         [Array]::Reverse($Properties)
         foreach ($Prop in $Properties) {
-            $Output = $Output.$Prop
+            if ($Prop -like '##*##') {
+                $output = $output.Where({$_.Name -eq ($Prop -replace '#')})
+            }
+            else {
+                $Output = $Output.$Prop
+            }
         }
     }
     $Output

--- a/src/private/Resolve-ArmFunction.ps1
+++ b/src/private/Resolve-ArmFunction.ps1
@@ -41,6 +41,12 @@ Function Resolve-ArmFunction {
     $Output = & $Command $Arguments $Template
 
     if ($Properties) {
+        if ($Properties[-1] -eq 'outputs') {
+            $Properties[-2] = "Where({`$_.name -eq $($Properties[-2])})"
+        }
+        if ($Output -is [TemplateResourceAst]) {
+            $Properties += 'Template','Properties'
+        }
         [Array]::Reverse($Properties)
         foreach ($Prop in $Properties) {
             $Output = $Output.$Prop

--- a/src/private/Resolve-ArmreferenceFunction.ps1
+++ b/src/private/Resolve-ArmreferenceFunction.ps1
@@ -7,4 +7,14 @@ Function Resolve-ArmreferenceFunction {
         [parameter()]
         [TemplateRootAst]$Template
     )
+
+    if ($Arguments.Token.StringValue -notmatch '\/subscriptions\/') {
+        if ($template -isnot [TemplateAst] -and $Template.Parent -is [TemplateAst]) {
+            $Template.Parent.Resources.Where({$_.Name -eq $Arguments.Token.StringValue -replace "'"})
+        }
+        elseif ($Template -is [TemplateAst]) {
+            $Template.Resources.Where({$_.Name -eq $Arguments.Token.StringValue -replace "'"})
+        }
+    }
+
 }

--- a/tests/unit/Resolve-ArmFunction.Tests.ps1
+++ b/tests/unit/Resolve-ArmFunction.Tests.ps1
@@ -17,11 +17,12 @@ InModuleScope ArmTemplateValidation {
 
                 Mock -CommandName Resolve-ArmReferenceFunction -MockWith {
                     [PSCustomObject]@{
-                        Outputs = [PSCustomObject]@{
-                            test = [PSCustomObject]@{
+                        Outputs = @(
+                            [PSCustomObject]@{
+                                Name = 'test'
                                 value = 'othertest'
                             }
-                        }
+                        )
                         inputs = 'teststring'
                     }
                 }
@@ -70,11 +71,12 @@ InModuleScope ArmTemplateValidation {
                 }
                 Mock -CommandName Resolve-ArmReferenceFunction -MockWith {
                     [PSCustomObject]@{
-                        Outputs = [PSCustomObject]@{
-                            test = [PSCustomObject]@{
+                        Outputs = @(
+                            [PSCustomObject]@{
+                                Name = 'test'
                                 value = 'othertest'
                             }
-                        }
+                        )
                         inputs = 'teststring'
                     }
                 }

--- a/tests/unit/Resolve-ArmFunction.Tests.ps1
+++ b/tests/unit/Resolve-ArmFunction.Tests.ps1
@@ -17,7 +17,7 @@ InModuleScope ArmTemplateValidation {
 
                 Mock -CommandName Resolve-ArmReferenceFunction -MockWith {
                     [PSCustomObject]@{
-                        Outputs = @(
+                        SomeObject = @(
                             [PSCustomObject]@{
                                 Name = 'test'
                                 value = 'othertest'
@@ -53,8 +53,8 @@ InModuleScope ArmTemplateValidation {
                 $Sut | Should -Be 'teststring'
             }
 
-            It "Should handle property access for multiple properties deep in [reference('test','item').outputs.test.value]" {
-                $Sut = Resolve-ArmFunction -InputString "[reference('test','item').outputs.test.value]" -Template $EmptyTemplate
+            It "Should handle property access for multiple properties deep in [reference('test','item').SomeObject.value]" {
+                $Sut = Resolve-ArmFunction -InputString "[reference('test','item').SomeObject.value]" -Template $EmptyTemplate
 
                 $Sut | Should -Be 'othertest'
             }
@@ -71,7 +71,7 @@ InModuleScope ArmTemplateValidation {
                 }
                 Mock -CommandName Resolve-ArmReferenceFunction -MockWith {
                     [PSCustomObject]@{
-                        Outputs = @(
+                        SomeObject = @(
                             [PSCustomObject]@{
                                 Name = 'test'
                                 value = 'othertest'
@@ -80,6 +80,23 @@ InModuleScope ArmTemplateValidation {
                         inputs = 'teststring'
                     }
                 }
+                Mock -CommandName Resolve-ArmReferenceFunction -MockWith {
+                    [TemplateResourceAst]::New([PSCustomObject]@{
+                        Type = 'Microsoft.Resources/Deployment'
+                        Name = 'ExampleDeployment'
+                        ApiVersion = '1970-01-01'
+                        Properties = [PSCustomObject]@{
+                            Template = [PSCustomObject]@{
+                                Outputs = @(
+                                    [PSCustomObject]@{
+                                        Name = 'example'
+                                        value = 'OutputValue'
+                                    }
+                                )
+                            }
+                        }
+                    }, ([TemplateRootAst]::New()))
+                } -ParameterFilter {$Arguments[0].Token.StringValue -eq "'thing'"}
             }
 
             It "Should call the concat function when passed an ArmValue for [contact('test','data')]" {
@@ -117,12 +134,20 @@ InModuleScope ArmTemplateValidation {
                 $Result | Should -Be 'teststring'
             }
 
-            It "Should handle property access for multiple properties deep in [reference('test','item').outputs.test.value]" {
-                $Sut = [ArmParser]::Parse("[reference('test','item').outputs.test.value]")
+            It "Should handle property access for multiple properties deep in [reference('test','item').SomeObject.value]" {
+                $Sut = [ArmParser]::Parse("[reference('test','item').SomeObject.value]")
 
                 $result = Resolve-ArmFunction -InputObject $Sut.Expression -Template $EmptyTemplate
 
                 $Result | Should -Be 'othertest'
+            }
+
+            It "Should handle returning values inside the outputs section of linked or nested tempaltes when passed [reference('thing').Outputs.example.value]" {
+                $Sut = [ArmParser]::Parse("[reference('thing').Outputs.example.value]")
+
+                $Result = Resolve-ArmFunction -InputObject $Sut.Expression -Template $EmptyTemplate
+
+                $Result | Should -Be 'OutputValue'
             }
 
         }

--- a/tests/unit/Resolve-ArmReferenceFunction.Tests.ps1
+++ b/tests/unit/Resolve-ArmReferenceFunction.Tests.ps1
@@ -1,0 +1,32 @@
+using module ..\..\Output\ArmTemplateValidation
+
+InModuleScope ArmTemplateValidation {
+
+    Describe "Testing Resolve-ArmResourceIdFunction" -Tag "Resolve-ArmResourceIdFunction" {
+
+        BeforeAll {
+            $Template = [TemplateAst]::New("$PSScriptRoot\TestData\TemplateAst\OneResource.json")
+        }
+
+        Context "Testing with a resource name" {
+
+            BeforeAll {
+                $Name = [ArmStringValue]::New(([ArmToken]::Create([ArmTokenType]::Literal, 0, 'teststorageaccount')))
+
+                $Sut = Resolve-ArmReferenceFunction -Arguments $Name -Template $Template.Resources[0]
+            }
+
+            It "Should return the resource AST" {
+                $Sut.GetType().Name | Should -Be 'TemplateResourceAst'
+            }
+
+            It "Should return the correct names resource AST" {
+                $Sut.Name | Should -Be 'teststorageaccount'
+            }
+        }
+
+        Context "Testing with a resource Id" {
+
+        }
+    }
+}


### PR DESCRIPTION
## Description

Resolve-ArmReferenceFunction should return the relevant object type back for whichever resources it's provided. This can then be used by Resolve-Function to pull out individual properties as required. Primary initial use case is for outputs from other templates. If we could do something useful with the resource id when passed that it would be good but I'm not sure how to handle that yet.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

